### PR TITLE
Add workbox-window dependency for web panel PWA build

### DIFF
--- a/apps/web-panel/package.json
+++ b/apps/web-panel/package.json
@@ -19,6 +19,7 @@
     "@tanstack/vue-query": "^5.59.20",
     "axios": "^1.6.0",
     "pinia": "^2.1.0",
+    "workbox-window": "^7.4.0",
     "vue": "^3.3.0",
     "vue-router": "^4.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       pinia:
         specifier: ^2.1.0
         version: 2.3.1(typescript@5.9.3)(vue@3.5.25)
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
       vue:
         specifier: ^3.3.0
         version: 3.5.25(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- add workbox-window runtime dependency required by the PWA registration helper
- update the lockfile to include the new web panel dependency

## Testing
- pnpm build --filter @terra-hub/web-panel *(fails: workspace packages missing node_modules because dependencies cannot be installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c83e76448320a6f0b481e29eb407)