### PR TITLE
Fix Pages build to use configured base URL

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           version: 8
 
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -39,7 +43,7 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Build web app
-        run: pnpm --filter @terra-hub/web-panel build
+        run: pnpm --filter @terra-hub/web-panel build -- --base=${{ steps.pages.outputs.base_url }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow to retrieve the Pages base URL
- pass the Pages base URL into the web panel build so generated asset paths are correct

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929cadb14808320bdf108c171cdaaeb)