### PR TITLE
Use Pages base URL for web panel build

### DIFF
--- a/apps/web-panel/vite.config.ts
+++ b/apps/web-panel/vite.config.ts
@@ -2,45 +2,55 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { VitePWA } from 'vite-plugin-pwa';
 
-export default defineConfig({
-  plugins: [
-    vue(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['icons/icon.svg'],
-      manifest: {
-        name: 'TerraHub Web Panel',
-        short_name: 'TerraHub',
-        description: 'Mobile-friendly control surface for TerraHub controllers',
-        theme_color: '#0f172a',
-        background_color: '#0b1224',
-        display: 'standalone',
-        start_url: '/',
-        icons: [
-          {
-            src: '/icons/icon.svg',
-            sizes: 'any',
-            type: 'image/svg+xml',
-            purpose: 'maskable any'
-          }
-        ]
-      },
-      workbox: {
-        runtimeCaching: [
-          {
-            urlPattern: /\/api\/controllers\/(discover|status).*/,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'controller-api',
-              networkTimeoutSeconds: 4,
-              cacheableResponse: { statuses: [0, 200] }
+export default defineConfig(() => {
+  const rawBase = process.env.npm_config_base || '/';
+  const normalizedBase = rawBase.startsWith('/') ? rawBase : `/${rawBase}`;
+  const base = normalizedBase.endsWith('/') ? normalizedBase : `${normalizedBase}/`;
+
+  const withBase = (path: string) => `${base}${path.replace(/^\/+/, '')}`;
+
+  return {
+    base,
+    plugins: [
+      vue(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        includeAssets: ['icons/icon.svg'],
+        manifest: {
+          name: 'TerraHub Web Panel',
+          short_name: 'TerraHub',
+          description: 'Mobile-friendly control surface for TerraHub controllers',
+          theme_color: '#0f172a',
+          background_color: '#0b1224',
+          display: 'standalone',
+          start_url: base,
+          scope: base,
+          icons: [
+            {
+              src: withBase('icons/icon.svg'),
+              sizes: 'any',
+              type: 'image/svg+xml',
+              purpose: 'maskable any'
             }
-          }
-        ]
-      }
-    })
-  ],
-  server: {
-    host: '0.0.0.0'
-  }
+          ]
+        },
+        workbox: {
+          runtimeCaching: [
+            {
+              urlPattern: /\/api\/controllers\/(discover|status).*/,
+              handler: 'NetworkFirst',
+              options: {
+                cacheName: 'controller-api',
+                networkTimeoutSeconds: 4,
+                cacheableResponse: { statuses: [0, 200] }
+              }
+            }
+          ]
+        }
+      })
+    ],
+    server: {
+      host: '0.0.0.0'
+    }
+  };
 });


### PR DESCRIPTION
## Summary
- normalize the Vite base path from the Pages `--base` CLI flag
- apply the configured base to the PWA manifest start URL, scope, and icon paths for GitHub Pages deployments

## Testing
- pnpm --filter @terra-hub/web-panel lint *(fails: local dependencies not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929cc124c7483208c39e728b87c9afb)